### PR TITLE
Schema refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,16 @@
 
 A simple site to practice some basic web skills and have a little fun learning about countries. The site currently features a list of all countries that is filterable by continent and sortable by name or population, as well as country and capital guessing games. Make an account to track your longest streak, and check out the leaderboard to see the best players!
 
+This site is written in [`Go`](https://go.dev/) using the [`echo`](https://echo.labstack.com/) web framework with an [`sqlite3`](https://www.sqlite.org/) backend. No `Javascript` is used; the site is statically rendered with `Go's` standard [html template package](https://pkg.go.dev/html/template).
+
 ## Roadmap
 
 [X] Country Guesser
+
 [X] Capital Guesser
+
 [X] Users
+
 [X] Leaderboard
+
 [ ] Population Guesser

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -21,8 +21,8 @@ type User struct {
     CurrentCountryScore int64
     LongestCapitalScore int64
     CurrentCapitalScore int64
-    CurrentCountry      CountryData
-    CurrentCapital      CountryData
+    CurrentCountry      string
+    CurrentCapital      string
     CreatedAt           time.Time
 }
 

--- a/internal/repositories/sqlite_user_repository.go
+++ b/internal/repositories/sqlite_user_repository.go
@@ -73,8 +73,6 @@ func (r *SQLiteUserRepository) AuthenticateUser(username, password string) (*mod
 
 func (r *SQLiteUserRepository) GetUserByUsername(username string) (*models.User, error) {
     var user models.User
-    var countryJSON string
-    var capitalJSON string
     query := `
         SELECT
             id,
@@ -98,18 +96,10 @@ func (r *SQLiteUserRepository) GetUserByUsername(username string) (*models.User,
         &user.CurrentCountryScore,
         &user.LongestCapitalScore,
         &user.CurrentCapitalScore,
-        &countryJSON,
-        &capitalJSON,
+        &user.CurrentCountry,
+        &user.CurrentCapital,
         &user.CreatedAt,
     )
-    if err != nil {
-        return nil, err
-    }
-    err = json.Unmarshal([]byte(countryJSON), &user.CurrentCountry)
-    if err != nil {
-        return nil, err
-    }
-    err = json.Unmarshal([]byte(capitalJSON), &user.CurrentCapital)
     if err != nil {
         return nil, err
     }
@@ -118,8 +108,6 @@ func (r *SQLiteUserRepository) GetUserByUsername(username string) (*models.User,
 
 func (r *SQLiteUserRepository) GetUserByID(id int64) (*models.User, error) {
     var user models.User
-    var countryJSON string
-    var capitalJSON string
     query := `
         SELECT
             id,
@@ -141,18 +129,10 @@ func (r *SQLiteUserRepository) GetUserByID(id int64) (*models.User, error) {
         &user.CurrentCountryScore,
         &user.LongestCapitalScore,
         &user.CurrentCapitalScore,
-        &countryJSON,
-        &capitalJSON,
+        &user.CurrentCountry,
+        &user.CurrentCapital,
         &user.CreatedAt,
     )
-    if err != nil {
-        return nil, err
-    }
-    err = json.Unmarshal([]byte(countryJSON), &user.CurrentCountry)
-    if err != nil {
-        return nil, err
-    }
-    err = json.Unmarshal([]byte(capitalJSON), &user.CurrentCapital)
     if err != nil {
         return nil, err
     }
@@ -181,8 +161,6 @@ func (r *SQLiteUserRepository) GetAllUsers() ([]*models.User, error) {
     var users []*models.User
     for rows.Next() {
         var user models.User
-        var countryJSON string
-        var capitalJSON string
         err := rows.Scan(
             &user.ID,
             &user.Username,
@@ -190,20 +168,12 @@ func (r *SQLiteUserRepository) GetAllUsers() ([]*models.User, error) {
             &user.CurrentCountryScore,
             &user.LongestCapitalScore,
             &user.CurrentCapitalScore,
-            &countryJSON,
-            &capitalJSON,
+            &user.CurrentCountry,
+            &user.CurrentCapital,
             &user.CreatedAt,
         )
         if err != nil {
             return users, err
-        }
-        err = json.Unmarshal([]byte(countryJSON), &user.CurrentCountry)
-        if err != nil {
-            return nil, err
-        }
-        err = json.Unmarshal([]byte(capitalJSON), &user.CurrentCapital)
-        if err != nil {
-            return nil, err
         }
         users = append(users, &user)
     }
@@ -298,7 +268,7 @@ func (r *SQLiteUserRepository) UpdateCapitalScore(userID int64, correct bool) er
 }
 
 func (r *SQLiteUserRepository) UpdateCurrentCountry(user *models.User) error {
-    nextCountryJSON, err := json.Marshal(models.GetRandomCountry())
+    nextCountry, err := json.Marshal(models.GetRandomCountry().Name.CommonName)
     if err != nil {
         return err
     }
@@ -309,7 +279,7 @@ func (r *SQLiteUserRepository) UpdateCurrentCountry(user *models.User) error {
                 current_country = ?
             WHERE id = ?
         ;`
-    _, err = r.DB.Exec(stmt, string(nextCountryJSON), user.ID)
+    _, err = r.DB.Exec(stmt, nextCountry, user.ID)
     if err != nil {
         return err
     }
@@ -317,7 +287,7 @@ func (r *SQLiteUserRepository) UpdateCurrentCountry(user *models.User) error {
 }
 
 func (r *SQLiteUserRepository) UpdateCurrentCapital(user *models.User) error {
-    nextCountryJSON, err := json.Marshal(models.GetRandomCountry())
+    nextCountry, err := json.Marshal(models.GetRandomCountry().Name.CommonName)
     stmt := `
             UPDATE
                 users
@@ -325,7 +295,7 @@ func (r *SQLiteUserRepository) UpdateCurrentCapital(user *models.User) error {
                 current_capital  = ?
             WHERE id = ?
         ;`
-    _, err = r.DB.Exec(stmt, string(nextCountryJSON), user.ID)
+    _, err = r.DB.Exec(stmt, nextCountry, user.ID)
     if err != nil {
         return err
     }

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -213,7 +213,7 @@ func getGuessCountry(c echo.Context) error {
     basePayload := models.NewBasePayload(user)
     var answerCountry models.CountryData
     if user != nil {
-        answerCountry = user.CurrentCountry
+        answerCountry = *models.GetCountryByName(user.CurrentCountry)
     } else {
         answerCountry = models.GetRandomCountry()
         cookie := middleware.SetCookie("answerCountryName", answerCountry.Name.CommonName)
@@ -231,7 +231,7 @@ func postGuessCountry(c echo.Context, userService services.UserService) error {
     basePayload := models.NewBasePayload(user)
     var answerCountry models.CountryData
     if user != nil {
-        answerCountry = user.CurrentCountry
+        answerCountry = *models.GetCountryByName(user.CurrentCountry)
     } else {
         answerCountryCookie, err := c.Cookie("answerCountryName")
         if err != nil {
@@ -270,7 +270,7 @@ func getGuessCapital(c echo.Context) error {
     // don't use countries where capital == null
     var answerCountry models.CountryData
     if user != nil {
-        answerCountry = user.CurrentCapital
+        answerCountry = *models.GetCountryByName(user.CurrentCapital)
     } else {
         for len(answerCountry.Capitals) < 1 {
             answerCountry = models.GetRandomCountry()
@@ -290,7 +290,7 @@ func postGuessCapital(c echo.Context, userService services.UserService) error {
     basePayload := models.NewBasePayload(user)
     var answerCountry models.CountryData
     if user != nil {
-        answerCountry = user.CurrentCapital
+        answerCountry = *models.GetCountryByName(user.CurrentCapital)
     } else {
         answerCountryCookie, err := c.Cookie("answerCapitalName")
         if err != nil {

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -70,18 +70,18 @@ func RegisterRoutes(e *echo.Echo, userService services.UserService) {
     })
 
     e.GET("/search_continents", func(c echo.Context) error {
-        return getContinents(c, userService)
+        return getContinents(c)
     })
 
     e.GET("/guess_countries", func(c echo.Context) error {
-        return getGuessCountry(c, userService)
+        return getGuessCountry(c)
     })
     e.POST("/guess_countries", func(c echo.Context) error {
         return postGuessCountry(c, userService)
     })
 
     e.GET("/guess_capitals", func(c echo.Context) error {
-        return getGuessCapital(c, userService)
+        return getGuessCapital(c)
     })
     e.POST("/guess_capitals", func(c echo.Context) error {
         return postGuessCapital(c, userService)
@@ -195,7 +195,7 @@ func postLogout(c echo.Context) error {
     return c.Redirect(301, "/")
 }
 
-func getContinents(c echo.Context, userService services.UserService) error {
+func getContinents(c echo.Context) error {
     basePayload := models.NewBasePayload(getUserFromContext(c))
     continents := models.GetAllContinents()
     allCountries := models.GetAllCountries()
@@ -208,7 +208,7 @@ func getContinents(c echo.Context, userService services.UserService) error {
 	return c.Render(200, "search_continents", payload)
 }
 
-func getGuessCountry(c echo.Context, userService services.UserService) error {
+func getGuessCountry(c echo.Context) error {
     user := getUserFromContext(c)
     basePayload := models.NewBasePayload(user)
     var answerCountry models.CountryData
@@ -264,7 +264,7 @@ func postGuessCountry(c echo.Context, userService services.UserService) error {
 	return c.Render(200, "guess_countries", payload)
 }
 
-func getGuessCapital(c echo.Context, userService services.UserService) error {
+func getGuessCapital(c echo.Context) error {
     user := getUserFromContext(c)
     basePayload := models.NewBasePayload(user)
     // don't use countries where capital == null
@@ -294,11 +294,7 @@ func postGuessCapital(c echo.Context, userService services.UserService) error {
     } else {
         answerCountryCookie, err := c.Cookie("answerCapitalName")
         if err != nil {
-            if err != http.ErrNoCookie {
-                c.Redirect(301, "/guess_capitals")
-                return err
-            }
-            return err
+            c.Redirect(301, "/guess_capitals")
         }
         answerCountry = *models.GetCountryByName(answerCountryCookie.Value)
     }
@@ -310,9 +306,11 @@ func postGuessCapital(c echo.Context, userService services.UserService) error {
         for _, capital := range answerCountry.Capitals {
             if capital == guessCapital {
                 passed = true
-                err := userService.UpdateCurrentCapital(user)
-                if err != nil {
-                    log.Println(err)
+                if user != nil {
+                    err := userService.UpdateCurrentCapital(user)
+                    if err != nil {
+                        log.Println(err)
+                    }
                 }
             }
         }
@@ -323,7 +321,9 @@ func postGuessCapital(c echo.Context, userService services.UserService) error {
     } else {
         guessCountry = guessCountries[0]
     }
-    userService.UpdateCapitalScore(user.ID, passed)
+    if user != nil {
+        userService.UpdateCapitalScore(user.ID, passed)
+    }
     countriesPayload := models.NewCountriesPayload(countries, &answerCountry, guessCountry, passed)
     payload := models.CombinePayloads(countriesPayload, *basePayload)
 	return c.Render(200, "guess_capitals", payload)

--- a/schemas/users.schema.1
+++ b/schemas/users.schema.1
@@ -1,0 +1,12 @@
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username                TEXT NOT NULL UNIQUE,
+    password                TEXT NOT NULL,
+    longest_country_score   TEXT NOT NULL DEFAULT 0,
+    current_country_score   TEXT NOT NULL DEFAULT 0,
+    longest_capital_score   TEXT NOT NULL DEFAULT 0,
+    current_capital_score   TEXT NOT NULL DEFAULT 0,
+    current_country         TEXT NOT NULL,
+    current_capital         TEXT NOT NULL,
+    created_at              TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
update how CurrentCountry and CurrentCapital were stored in db. formerly the entire JSON object was stored as a string for each country (models.CountryData). now only the country.Name.Common is stored, and a GetCountryByName is used to get the full object when needed. storing the object as JSON directly may cause problems later if the attributes of the object change